### PR TITLE
Add ability to specify main class

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -29,8 +29,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.netflix.rxjava</groupId>
-      <artifactId>rxjava-core</artifactId>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
     </dependency>
     <dependency>
       <groupId>org.robovm</groupId>

--- a/client/src/main/java/org/robovm/junit/client/TestClient.java
+++ b/client/src/main/java/org/robovm/junit/client/TestClient.java
@@ -49,6 +49,7 @@ import org.robovm.libimobiledevice.IDeviceConnection;
 
 import rx.Observable;
 import rx.Subscriber;
+import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 

--- a/client/src/main/java/org/robovm/junit/client/TestClient.java
+++ b/client/src/main/java/org/robovm/junit/client/TestClient.java
@@ -69,7 +69,7 @@ public class TestClient extends LaunchPlugin {
     }
     private static class Terminator extends Waiter {}
     
-    public static final String SERVER_CLASS_NAME = "org.robovm.junit.server.TestServer";
+    public static String SERVER_CLASS_NAME = "org.robovm.junit.server.TestServer";
 
     private ServerPortReader serverPortReader;
     private File oldStdOutFifo;
@@ -79,6 +79,10 @@ public class TestClient extends LaunchPlugin {
     private RunListener runListener;
 
     public TestClient() {
+    }
+
+    public void setMainClass(Class mainClass) {
+        SERVER_CLASS_NAME = mainClass.getName();
     }
 
     public TestClient runTests(String ... testsToRun) {

--- a/client/src/main/java/org/robovm/junit/client/TestClient.java
+++ b/client/src/main/java/org/robovm/junit/client/TestClient.java
@@ -69,7 +69,7 @@ public class TestClient extends LaunchPlugin {
     }
     private static class Terminator extends Waiter {}
     
-    public static String SERVER_CLASS_NAME = "org.robovm.junit.server.TestServer";
+    public static final String SERVER_CLASS_NAME = "org.robovm.junit.server.TestServer";
 
     private ServerPortReader serverPortReader;
     private File oldStdOutFifo;
@@ -77,12 +77,14 @@ public class TestClient extends LaunchPlugin {
     private OutputStream defaultStdOutStream;
     private LinkedBlockingQueue<Object> runQueue = new LinkedBlockingQueue<>();
     private RunListener runListener;
+    private String mainClass;
 
     public TestClient() {
+        mainClass = SERVER_CLASS_NAME;
     }
 
-    public void setMainClass(Class mainClass) {
-        SERVER_CLASS_NAME = mainClass.getName();
+    public TestClient(Class mainClass) {
+        this.mainClass = mainClass.getName();
     }
 
     public TestClient runTests(String ... testsToRun) {
@@ -241,7 +243,7 @@ public class TestClient extends LaunchPlugin {
             throw new IllegalArgumentException("RoboVM configuration cannot be null");
         }
 
-        configBuilder.mainClass(SERVER_CLASS_NAME);
+        configBuilder.mainClass(mainClass);
         configBuilder.addForceLinkClass("com.android.org.conscrypt.OpenSSLProvider");
         configBuilder.addForceLinkClass("com.android.org.conscrypt.OpenSSLMessageDigestJDK**");
         

--- a/client/src/test/java/org/robovm/junit/client/TestClientTest.java
+++ b/client/src/test/java/org/robovm/junit/client/TestClientTest.java
@@ -78,6 +78,28 @@ public class TestClientTest {
     }
 
     @Test
+    public void testSuccessfulWholeClassRunWithCustomMain() throws Throwable {
+        TestClient client = new TestClient(org.robovm.junit.launcher.TestAppLauncher.class);
+        TestRunListener listener = new TestRunListener();
+        client.setRunListener(listener);
+        Config config = client.configure(createConfig()).build();
+        AppCompiler appCompiler = new AppCompiler(config);
+        appCompiler.compile();
+
+        LaunchParameters launchParameters = config.getTarget().createLaunchParameters();
+        Process process = appCompiler.launchAsync(launchParameters);
+        client.runTests(RunnerClass.class.getName()).terminate();
+        process.waitFor();
+        appCompiler.launchAsyncCleanup();
+
+        assertEquals("2 successful tests expected", 2, listener.successful.size());
+        assertTrue(listener.successful.contains("testSuccessfulTest1(" + RunnerClass.class.getName() + ")"));
+        assertTrue(listener.successful.contains("testSuccessfulTest2(" + RunnerClass.class.getName() + ")"));
+        assertEquals("1 failed test expected", 1, listener.failed.size());
+        assertTrue(listener.failed.contains("testShouldFail(" + RunnerClass.class.getName() + "): 1 == 2"));
+    }
+
+    @Test
     public void testSuccessfulWholeClassRun() throws Throwable {
         TestClient client = new TestClient();
         TestRunListener listener = new TestRunListener();

--- a/client/src/test/java/org/robovm/junit/launcher/TestAppLauncher.java
+++ b/client/src/test/java/org/robovm/junit/launcher/TestAppLauncher.java
@@ -1,0 +1,27 @@
+package org.robovm.junit.launcher;
+
+import org.robovm.junit.server.TestServer;
+
+import java.io.IOException;
+
+
+public class TestAppLauncher {
+    public static void main(String[] args) throws IOException {
+        /*
+         * The iOS simulator seems to relaunch apps that quit too fast or don't
+         * call into the UIKit event loop. The simulator doesn't preserve args
+         * when relaunching. The TestClient sets a special system property on
+         * the command line. If it's not set we now that we have been
+         * relaunched. In that case we return immediately.
+         */
+        if (System.getProperty("os.name").equals("iOS Simulator")
+                && !Boolean.getBoolean("robovm.launchedFromTestClient")) {
+            return;
+        }
+
+        System.err.println(TestServer.class.getName() + " [DEBUG]: Running");
+
+        new TestServer().run();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
         <version>${robovm.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.netflix.rxjava</groupId>
-        <artifactId>rxjava-core</artifactId>
-        <version>0.18.4</version>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>1.0.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,8 +23,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.netflix.rxjava</groupId>
-      <artifactId>rxjava-core</artifactId>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
     </dependency>
   </dependencies>
 

--- a/server/src/main/java/org/robovm/junit/server/TestServer.java
+++ b/server/src/main/java/org/robovm/junit/server/TestServer.java
@@ -85,30 +85,30 @@ public class TestServer {
             System.out.println(TestServer.class.getName() + ": port=" + serverSocket.getLocalPort());
             try (Socket socket = serverSocket.accept()) {
                 socketObservable = run(socket.getInputStream(), socket.getOutputStream());
-				socketObservable
-				.filter(new Func1<String, Boolean>() {
-					@Override
-					public Boolean call(String s) {
-						return s.length() > 0;
-					}
-				}).subscribe(new Action1<String>() {
-					@Override
-					public void call(String string) {
-						debug("Processing command: " + string);
-						processCommand(string);
-					}
-				}, new Action1<Throwable>() {
-					@Override
-					public void call(Throwable throwable) {
-						debug("Error running tests");
-						printStackTrace(throwable);
-					}
-				}, new Action0() {
-					@Override
-					public void call() {
-						debug("Finished test run");
-					}
-				});
+                socketObservable
+                .filter(new Func1<String, Boolean>() {
+                        @Override
+                        public Boolean call(String s) {
+                                return s.length() > 0;
+                        }
+                }).subscribe(new Action1<String>() {
+                        @Override
+                        public void call(String string) {
+                                debug("Processing command: " + string);
+                                processCommand(string);
+                        }
+                }, new Action1<Throwable>() {
+                        @Override
+                        public void call(Throwable throwable) {
+                                debug("Error running tests");
+                                printStackTrace(throwable);
+                        }
+                }, new Action0() {
+                        @Override
+                        public void call() {
+                                debug("Finished test run");
+                        }
+                });
             }
         }        
     }

--- a/server/src/main/java/org/robovm/junit/server/TestServer.java
+++ b/server/src/main/java/org/robovm/junit/server/TestServer.java
@@ -75,8 +75,6 @@ public class TestServer {
         });
         
         new TestServer().run();
-        debug("Exiting");
-        System.exit(0);
     }
 
     public void run() throws IOException {
@@ -106,7 +104,9 @@ public class TestServer {
                 }, new Action0() {
                         @Override
                         public void call() {
-                                debug("Finished test run");
+                            debug("Finished test run");
+                            debug("Exiting");
+                            System.exit(0);
                         }
                 });
             }

--- a/server/src/main/java/org/robovm/junit/server/TestServer.java
+++ b/server/src/main/java/org/robovm/junit/server/TestServer.java
@@ -32,6 +32,7 @@ import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func1;
+import rx.schedulers.Schedulers;
 
 /**
  * Server side of the bridge between the tester (IDE, Maven, Gradle, etc) and
@@ -43,8 +44,8 @@ public class TestServer {
 
     private static RoboTestListener listener;
     private static JUnitCore jUnitCore;
-
-    private volatile boolean stopped = false;
+	
+    private Observable<String> socketObservable;
 
     public static void main(String[] args) throws IOException {
         /*
@@ -83,13 +84,37 @@ public class TestServer {
         try (ServerSocket serverSocket = new ServerSocket(0)) {
             System.out.println(TestServer.class.getName() + ": port=" + serverSocket.getLocalPort());
             try (Socket socket = serverSocket.accept()) {
-                run(socket.getInputStream(), socket.getOutputStream());
+                socketObservable = run(socket.getInputStream(), socket.getOutputStream());
+				socketObservable
+				.filter(new Func1<String, Boolean>() {
+					@Override
+					public Boolean call(String s) {
+						return s.length() > 0;
+					}
+				}).subscribe(new Action1<String>() {
+					@Override
+					public void call(String string) {
+						debug("Processing command: " + string);
+						processCommand(string);
+					}
+				}, new Action1<Throwable>() {
+					@Override
+					public void call(Throwable throwable) {
+						debug("Error running tests");
+						printStackTrace(throwable);
+					}
+				}, new Action0() {
+					@Override
+					public void call() {
+						debug("Finished test run");
+					}
+				});
             }
         }        
     }
 
-    public void run(final InputStream in, final OutputStream out) {
-        Observable.create(new Observable.OnSubscribe<String>() {
+    public Observable<String> run(final InputStream in, final OutputStream out) {
+        return Observable.create(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> subscriber) {
                 try {
@@ -102,39 +127,16 @@ public class TestServer {
 
                     String line = null;
 
-                    while (!stopped && (line = reader.readLine()) != null) {
+                    while (!subscriber.isUnsubscribed() && (line = reader.readLine()) != null) {
                         if (!subscriber.isUnsubscribed()) {
                             subscriber.onNext(line);
                         }
                     }
-
                     subscriber.onCompleted();
                 } catch (Throwable e) {
                     subscriber.onError(e);
                     printStackTrace(e);
                 }
-            }
-        }).filter(new Func1<String, Boolean>() {
-            @Override
-            public Boolean call(String s) {
-                return s.length() > 0;
-            }
-        }).subscribe(new Action1<String>() {
-            @Override
-            public void call(String string) {
-                debug("Processing command: " + string);
-                processCommand(string);
-            }
-        }, new Action1<Throwable>() {
-            @Override
-            public void call(Throwable throwable) {
-                debug("Error running tests");
-                printStackTrace(throwable);
-            }
-        }, new Action0() {
-            @Override
-            public void call() {
-                debug("Finished test run");
             }
         });
     }
@@ -151,7 +153,7 @@ public class TestServer {
             cmd = Command.valueOf(idx != -1 ? commandLine.substring(0, idx) : commandLine);
         } catch (IllegalArgumentException e) {
             error("Unrecognized command: " + commandLine);
-            stopped = true;
+            socketObservable.unsubscribeOn(Schedulers.immediate());
             return;
         }
 
@@ -169,7 +171,7 @@ public class TestServer {
             }
             break;
         case terminate:
-            stopped = true;
+            socketObservable.unsubscribeOn(Schedulers.immediate());
             break;
         }
     }


### PR DESCRIPTION
Add the ability to specify the main launcher class.
This will help when testing UI-related functionality where a UI must be presented  and needs to be run in a blocking main function.

I've also bumped the Rx version and cleaned up a bit of the flow in the ```TestServer``` class