### PR TITLE
rxjava version bump and refactor

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -29,8 +29,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.netflix.rxjava</groupId>
-      <artifactId>rxjava-core</artifactId>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
     </dependency>
     <dependency>
       <groupId>org.robovm</groupId>

--- a/client/src/main/java/org/robovm/junit/client/TestClient.java
+++ b/client/src/main/java/org/robovm/junit/client/TestClient.java
@@ -69,7 +69,7 @@ public class TestClient extends LaunchPlugin {
     }
     private static class Terminator extends Waiter {}
     
-    public static final String SERVER_CLASS_NAME = "org.robovm.junit.server.TestServer";
+    public static String SERVER_CLASS_NAME = "org.robovm.junit.server.TestServer";
 
     private ServerPortReader serverPortReader;
     private File oldStdOutFifo;
@@ -79,6 +79,10 @@ public class TestClient extends LaunchPlugin {
     private RunListener runListener;
 
     public TestClient() {
+    }
+
+    public void setMainClass(Class mainClass) {
+        SERVER_CLASS_NAME = mainClass.getName();
     }
 
     public TestClient runTests(String ... testsToRun) {

--- a/client/src/test/java/org/robovm/junit/client/TestClientTest.java
+++ b/client/src/test/java/org/robovm/junit/client/TestClientTest.java
@@ -16,17 +16,6 @@
  */
 package org.robovm.junit.client;
 
-import static org.junit.Assert.*;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -37,40 +26,20 @@ import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.Config.Home;
 import org.robovm.compiler.log.ConsoleLogger;
 import org.robovm.compiler.target.LaunchParameters;
-import org.robovm.junit.protocol.Command;
-import org.robovm.junit.server.TestServer;
 import org.robovm.maven.resolver.RoboVMResolver;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link TestClient}.
  */
 public class TestClientTest {
-
-    @Test
-    public void testSuccessfulWholeClassRunOutsideOfRoboVM() throws Exception {
-        final TestServer testServer = new TestServer();
-        PipedOutputStream cmdStream = new PipedOutputStream();
-        final PipedInputStream in = new PipedInputStream(cmdStream);
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        Thread t = new Thread() {
-            public void run() {
-                testServer.run(in, out);
-            }
-        };
-        t.start();
-
-        OutputStreamWriter cmdWriter = new OutputStreamWriter(cmdStream);
-        cmdWriter.write(Command.run + " " + RunnerClass.class.getName() + "\n");
-        cmdWriter.flush();
-        cmdWriter.write(Command.terminate + "\n");
-        cmdWriter.flush();
-
-        t.join();
-
-        String result = new String(out.toByteArray(), "ASCII");
-        System.out.println(result);
-        assertFalse(result.isEmpty());
-    }
 
     @Test
     public void testSuccessfulWholeClassRun() throws Throwable {

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
         <version>${robovm.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.netflix.rxjava</groupId>
-        <artifactId>rxjava-core</artifactId>
-        <version>0.18.4</version>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>1.0.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,8 +23,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.netflix.rxjava</groupId>
-      <artifactId>rxjava-core</artifactId>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
     </dependency>
   </dependencies>
 

--- a/server/src/test/java/org/robovm/junit/server/RunnerClass.java
+++ b/server/src/test/java/org/robovm/junit/server/RunnerClass.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.robovm.junit.server;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RunnerClass {
+
+    @Test
+    public void testSuccessfulTest1() {
+        assertFalse(1 == 2);
+    }
+
+    @Test
+    public void testSuccessfulTest2() {
+        assertNotEquals(0, System.currentTimeMillis());
+    }
+
+    @Test
+    public void testShouldFail() {
+        assertTrue("1 == 2", 1 == 2);
+    }
+}

--- a/server/src/test/java/org/robovm/junit/server/TestServerTest.java
+++ b/server/src/test/java/org/robovm/junit/server/TestServerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.robovm.junit.server;
+
+import org.junit.Test;
+import org.robovm.junit.protocol.Command;
+import rx.functions.Action1;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by ash on 18/06/2015.
+ */
+public class TestServerTest {
+
+    @Test
+    public void testSuccessfulWholeClassRunOutsideOfRoboVM() throws Exception {
+        final TestServer testServer = new TestServer();
+        PipedOutputStream cmdStream = new PipedOutputStream();
+        final PipedInputStream in = new PipedInputStream(cmdStream);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        OutputStreamWriter cmdWriter = new OutputStreamWriter(cmdStream);
+        cmdWriter.write(Command.run + " " + RunnerClass.class.getName() + "\n");
+        cmdWriter.flush();
+        cmdWriter.write(Command.terminate + "\n");
+        cmdWriter.flush();
+
+        final ArrayList<String> results = new ArrayList<>();
+
+        /* take two emissions */
+        testServer.run(in, out).take(2).subscribe(new Action1<String>() {
+            @Override
+            public void call(String s) {
+                results.add(s);
+            }
+        });
+
+        System.out.println(results.get(0));
+        assertTrue(results.get(0).equals(Command.run + " " + RunnerClass.class.getName()));
+        System.out.println(results.get(1));
+        assertTrue(results.get(1).equals(Command.terminate.toString()));
+    }
+
+}


### PR DESCRIPTION
Bumped RxJava version to 1.0.9, reworked one of the tests and moved one of the tests from the client module to the server module -- this is for two reasons:
1) it belongs there
2) the RxJava changes I made caused automated test issues because of the module deps and jar shading 

I've also added a new method to TestClient to make it easier to specify a different main class